### PR TITLE
Add `api-version: 1.13`

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,6 +3,7 @@ main: com.projectg.geyserupdater.spigot.SpigotUpdater
 version: ${project.version}
 depend: [Geyser-Spigot]
 description: Automatically or manually downloads new builds of Geyser and applies them on server restart.
+api-version: 1.13
 
 commands:
   geyserupdate:


### PR DESCRIPTION
Stops legacy material support from being initalised, removing this warn:

```
[Server thread/WARN]: Initializing Legacy Material Support. Unless you have legacy plugins and/or data this is a bug!
[Server thread/WARN]: Legacy plugin GeyserUpdater v1.5.0 does not specify an api-version.
```